### PR TITLE
The application was crashing on startup due to a null pointer excepti…

### DIFF
--- a/app/src/main/java/com/example/smarttodo/data/Task.kt
+++ b/app/src/main/java/com/example/smarttodo/data/Task.kt
@@ -13,7 +13,9 @@ data class Task(
     val description: String = "",
     val priority: Int = 1,
     val isCompleted: Boolean = false,
-    val createdAt: Date = Date(),
+    // This is nullable to prevent crashes from legacy data that might have null creation dates.
+    // The app ensures new tasks always have a non-null date.
+    val createdAt: Date? = Date(),
     val dueDate: Date? = null,
     val hasReminder: Boolean = false
 ) : Serializable


### PR DESCRIPTION
…on during Room database initialization.

This was caused by a data inconsistency where the `Task.createdAt` field, defined as non-nullable in the data class, was encountering `NULL` values in the database from legacy data. When Room's TypeConverter tried to assign a `null` value to this non-nullable field, the app would crash.

This fix resolves the issue by making the `createdAt` field nullable in the `Task` data class (`Date?`). This makes the data model more robust to inconsistencies in the database, preventing the crash. A comment has been added to clarify why the field is nullable.

This change is safe because the `createdAt` field is not read directly anywhere in the app; it is only used for sorting tasks in the database queries.