### PR TITLE
The application was crashing on startup with an `IllegalStateExceptio…

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Dark Theme for Smart To-Do -->
-    <style name="Theme.SmartToDo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.SmartToDo" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primary_dark</item>
         <item name="colorOnPrimary">@color/white</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.SmartToDo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.SmartToDo" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primary_dark</item>
         <item name="colorOnPrimary">@color/white</item>


### PR DESCRIPTION
…n` because the theme (`Theme.SmartToDo`) inherited from `.DarkActionBar` while the code in `MainActivity` was programmatically setting its own Toolbar using `setSupportActionBar`. This created a conflict.

This commit resolves the crash by changing the parent theme in both `values/themes.xml` and `values-night/themes.xml` from `Theme.MaterialComponents.DayNight.DarkActionBar` to `Theme.MaterialComponents.DayNight.NoActionBar`.

This removes the default action bar provided by the theme, allowing the custom Toolbar to be set without conflict, as recommended by the exception's message.